### PR TITLE
Change SINGLESHOT max attenuation behaviour

### DIFF
--- a/docs/explanations/interface.md
+++ b/docs/explanations/interface.md
@@ -87,7 +87,9 @@ If the system is put into `SINGLESHOT` mode, maximum attenuation is set and the
 Once data messages start, the system adjusts attenuation as normal until a message is
 received that does not cause an adjustment. At this point the attenuation level is
 considered stable and the `SINGLESHOT_COMPELETE` state is entered, which pauses the
-adjustment at the current attenuation level without timing out.
+adjustment at the current attenuation level without timing out. Max attenuation will
+only be set at the beginning of the first run, or if an error state is entered. Between
+runs, the attenuation will be kept at the previously stable value.
 
 This mode allows higher level software to use the automatic attenuation to optimise the
 attenuation level and then capture a single optimal image at that attenuation.

--- a/tests/test_pmac_filter_control.py
+++ b/tests/test_pmac_filter_control.py
@@ -510,11 +510,11 @@ def test_singleshot_scan(
 
     # Repeat for next run
     pfc.request({"command": "singleshot"})
-    pfc.assert_status_equal({"mode": 2, "state": 1})
+    pfc.assert_status_equal({"mode": 2, "state": 1, "current_attenuation": 13})
 
     # Reduce attenuation
     sim.send_frame({"high2": 0, "high1": 0, "low2": 0})
-    pfc.assert_status_equal({"mode": 2, "state": 2, "current_attenuation": 13})
+    pfc.assert_status_equal({"mode": 2, "state": 2, "current_attenuation": 11})
 
     # Stablise for timeout duration
     sim.send_blank()


### PR DESCRIPTION
Requirements for SINGLESHOT mode have now changed to stay at the previously stabilised attenuation instead of resetting to max attenuation between singleshot runs to limit the heating up of the motors.